### PR TITLE
chore: textlint を mdx にもかけるように

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -2,5 +2,8 @@
   "rules": {
     "preset-ja-technical-writing": true,
     "preset-jtf-style": true
+  },
+  "plugins": {
+    "mdx": true
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "textlint.languages": ["markdown", "mdx"]
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prettier": "3.5.3",
     "prettier-plugin-astro": "0.14.1",
     "textlint": "14.6.0",
+    "textlint-plugin-mdx": "^1.0.2",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
     "textlint-rule-preset-jtf-style": "3.0.2",
     "typescript": "5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       textlint:
         specifier: 14.6.0
         version: 14.6.0
+      textlint-plugin-mdx:
+        specifier: ^1.0.2
+        version: 1.0.2(typescript@5.8.3)
       textlint-rule-preset-ja-technical-writing:
         specifier: 12.0.2
         version: 12.0.2
@@ -3236,6 +3239,11 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  textlint-plugin-mdx@1.0.2:
+    resolution: {integrity: sha512-La+pgFdhw78F93PKm/c8IYipZPUMOxuwSVX9ZcVMT9Q9f3xF7N5rU37dotVjn+D8kmN0AJaxm0qtT5nEEP51mA==}
+    peerDependencies:
+      typescript: ^5.0.0
 
   textlint-rule-helper@2.3.1:
     resolution: {integrity: sha512-b1bijvyiUmKinfFE5hkQMSXs3Ky8jyZ3Y6SOoTRJKV9HLL2LWUVFAUezO7z4FpAkVvYruDYWCwA5qWV8GmvyUw==}
@@ -7926,6 +7934,10 @@ snapshots:
       strip-ansi: 6.0.1
 
   text-table@0.2.0: {}
+
+  textlint-plugin-mdx@1.0.2(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
 
   textlint-rule-helper@2.3.1:
     dependencies:


### PR DESCRIPTION
mdx にかかってなかった


任意のmdxファイルに以下の文言を入れて VS Code or Cursor とコマンドライン上でエラーが出ることを確認

```md
こんにちわ！
```



## チェックリスト
- [x] 機能実装向け：ビルド、テストは正常に動作しますか？
- [x] 機能実装向け：意図していないデバッグコードはありませんか？
- [x] 機能実装向け：PRにレビュー優先度のラベルをつけましたか？
- [x] PRにレビューレベルのラベルをつけましたか？
- [ ] ガイドライン向け: 変更箇所の日本語は適切ですか？
- [ ] ガイドライン向け: 変更箇所のフォーマットは統一されていますか？


<!-- レビューレベルの分類ラベルの例:
各観点から複数選択可能とする。

ただし、ノールックで Approve してほしい場合には（何も選択されないとき、見た側が「選択忘れ」なのか区別つかず不便なので）「ノールック」を選択する。

- Review: ノールック
    - description: 「まったく見ないで Approve する」
- Review観点1: 軽く目を通す
    - description: 「コードを読んで違和感がないかチェックする」
- Review観点2: 動作確認
    - description: 「レビューにあたって、ローカル環境での動作確認を要する」
- Review観点3: 仕様
    - description: 「レビューにあたって、仕様の理解・確認を要する」
- Review観点4: 設計
    - description: 「レビューにあたって、設計の観点からの違和感等がないか確認する」
