### PR TITLE
fix: 2.4.7ガイドラインの画像表示を修正

### DIFF
--- a/src/content/docs/guidelines/2.4.7.mdx
+++ b/src/content/docs/guidelines/2.4.7.mdx
@@ -7,6 +7,8 @@ import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
 import dedent from 'dedent';
 import LiveCodeExample from '../../../components/LiveCodeExample.tsx';
 import { Sandpack } from "@codesandbox/sandpack-react";
+import { Image } from 'astro:assets';
+import xScreenshot from '../../../assets/images/2.4.7/x-screenshot.jpg';
 
 <Aside type="tip" title="このガイドラインで目指すこと">
 キーボード操作や画面読み上げなどを利用するユーザーが、現在どの要素を操作しようとしているかを視覚的に把握できるようにします。
@@ -302,7 +304,7 @@ Aさんは大量のデータをシステムに入力する業務を担当して�
 <Aside type="tip" title="実際のサービスでの工夫例">
 X（旧Twitter）などはフォーカスインジケーターの工夫を行なっており、デザインとの整合性を保ちながら視認性を確保しています。
 
-![Xのフォーカス表示例](/src/assets/images/2.4.7/x-screenshot.jpg)
+<Image src={xScreenshot} alt="Xのフォーカス表示例" />
 
 上の画像では、「いいね」ボタンにフォーカスが当たった際に、ピンクの円形の背景が表示され、どのボタンが選択されているかが明確に分かります。従来のoutlineではなく、デザインに溶け込む形でフォーカス状態を表現している好例です。
 </Aside>


### PR DESCRIPTION
## チケットURL
<!-- 該当するチケットがあれば記載 -->
N/A

## ラベル
documentation

## 概要
2.4.7ガイドラインページで画像が正しく表示されない問題を修正しました。
Astroのビルドシステムに適合するよう、画像の読み込み方法を変更しています。

### 変更理由
- Markdownの直接的な画像パス指定では、Astroのビルドプロセスで画像が正しく処理されない
- `astro:assets`のImageコンポーネントを使用することで、画像の最適化とビルド時の適切な処理が行われる

## 確認用URL

http://localhost:4322/accessibility-guidelines/guidelines/247/

## スクリーンショット

変更前

<img width="1512" height="945" alt="画像が表示されない状態" src="https://github.com/user-attachments/assets/813f19eb-e007-40f3-b56a-51090949c66f" />

変更後
<img width="1512" height="945" alt="画像が表示されている状態" src="https://github.com/user-attachments/assets/fb12dc12-cb8c-4573-9b2b-67acf6c9d2d5" />


## その他
- `astro:assets`から`Image`コンポーネントをインポート
- 画像アセットを適切にインポート  
- MarkdownのimgタグをAstroのImageコンポーネントに置き換え

## チェックリスト
- [x] ガイドライン向け: 変更箇所の日本語は適切ですか？
- [x] ガイドライン向け: 変更箇所のフォーマットは統一されていますか？
- [x] PRにレビューレベルのラベルをつけましたか？

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>